### PR TITLE
Updated TripAdvisor API service and added an Azure startup file

### DIFF
--- a/features/travelagent/trip_advisor.py
+++ b/features/travelagent/trip_advisor.py
@@ -14,6 +14,7 @@ class TripAdvisor:
         """
         url = f"{self.__base_url}/location/search?searchQuery={search_query}&category={category}&language=en&key={self.__api_key}"
         headers = {
+            "Referer": "holidaymatch.streamlit.app",
             "accept": "application/json"
         }
         async with httpx.AsyncClient() as client:
@@ -36,6 +37,7 @@ class TripAdvisor:
         """
         url = f"{self.__base_url}/location/{location_id}/photos?language=en&key={self.__api_key}"
         headers = {
+            "Referer": "holidaymatch.streamlit.app",
             "accept": "application/json"
         }
         async with httpx.AsyncClient() as client:
@@ -45,6 +47,7 @@ class TripAdvisor:
     async def location_details_async(self, location_id: int):
         url = f"{self.__base_url}/location/{location_id}/details?language=en&currency=CHF&key={self.__api_key}"
         headers = {
+            "Referer": "holidaymatch.streamlit.app",
             "accept": "application/json"
         }
         async with httpx.AsyncClient() as client:

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,1 @@
+python -m streamlit run app.py --server.port 8000 --server.address 0.0.0.0


### PR DESCRIPTION
This pull request includes changes to the `features/travelagent/trip_advisor.py` file to add a `Referer` header to HTTP requests and a new command in the `run.sh` script to start the Streamlit app.

HTTP request improvements:

* [`features/travelagent/trip_advisor.py`](diffhunk://#diff-b3d250e783cd1a1684d20c3a57029b1b689d8da8a44dcc12e2323c786fc33d5bR17): Added `"Referer": "holidaymatch.streamlit.app"` header to `location_search_async`, `location_photos_async`, and `location_details_async` methods to specify the origin of the requests. [[1]](diffhunk://#diff-b3d250e783cd1a1684d20c3a57029b1b689d8da8a44dcc12e2323c786fc33d5bR17) [[2]](diffhunk://#diff-b3d250e783cd1a1684d20c3a57029b1b689d8da8a44dcc12e2323c786fc33d5bR40) [[3]](diffhunk://#diff-b3d250e783cd1a1684d20c3a57029b1b689d8da8a44dcc12e2323c786fc33d5bR50)

Script updates:

* [`run.sh`](diffhunk://#diff-d31ce0453051853c17ba2a5225b3d1bfab548e095bab0967d6acfd1b3ce1b35dR1): Added a command to run the Streamlit app on port 8000 and bind it to all available IP addresses.