### PR TITLE
Bugfix in reset

### DIFF
--- a/lib/handlers.py
+++ b/lib/handlers.py
@@ -183,6 +183,7 @@ def handle_user_preferences():
                 if st.button("Restart", use_container_width=True):
                     # Reset the user preferences and start over
                     reset_preferences()
+                    update_ui()
 
             with col2:
                 if st.button('Get suggestions', type="primary", icon=":material/model_training:", use_container_width=True):


### PR DESCRIPTION
This pull request includes a small change to the `lib/handlers.py` file. The change ensures that the user interface is updated after resetting user preferences.

* [`lib/handlers.py`](diffhunk://#diff-83eb31ee415d9c40df27b208065dfccc7460dff8d8e50757e2b6fedb23ad2e3eR186): Added a call to `update_ui()` after resetting user preferences in the `handle_user_preferences` function.